### PR TITLE
Fix byte reading logic

### DIFF
--- a/src/main/java/net/arnx/wmf2svg/io/DataInput.java
+++ b/src/main/java/net/arnx/wmf2svg/io/DataInput.java
@@ -167,14 +167,19 @@ public class DataInput {
 		throw new EOFException();
 	}
 
-	public byte[] readBytes(int n) throws IOException, EOFException {
-		byte[] array = new byte[n];
-		if (in.read(array) == n) {
-			count += n;
-			return array;
-		}
-		throw new EOFException();
-	}
+       public byte[] readBytes(int n) throws IOException, EOFException {
+               byte[] array = new byte[n];
+               int offset = 0;
+               while (offset < n) {
+                       int r = in.read(array, offset, n - offset);
+                       if (r == -1) {
+                               throw new EOFException();
+                       }
+                       offset += r;
+               }
+               count += n;
+               return array;
+       }
 
 	public void setCount(int count) {
 		this.count = count;


### PR DESCRIPTION
## Summary
- ensure `DataInput.readBytes` reads the entire requested byte count

## Testing
- `./gradlew test` *(fails: Unable to download gradle wrapper)*

------
https://chatgpt.com/codex/tasks/task_e_6840958cee4083299a256877b2415ab8